### PR TITLE
Bug Fix SDK 481 and SDK 482

### DIFF
--- a/Commander/vault/RecordCommands.cs
+++ b/Commander/vault/RecordCommands.cs
@@ -813,7 +813,7 @@ namespace Commander
                     shareOptions.Expiration = DateTimeOffset.Now + ts;
                 }
                 await context.Vault.ShareRecordWithUser(record.Uid, options.Email, shareOptions);
-                Console.WriteLine("Successfuly shared the record {record.Uid} with user {options.Email}");
+                Console.WriteLine($"Successfully shared the record {record.Uid} with user {options.Email}");
             }
             catch (NoActiveShareWithUserException e)
             {

--- a/KeeperSdk/vault/KeeperNSFMutations.cs
+++ b/KeeperSdk/vault/KeeperNSFMutations.cs
@@ -363,6 +363,20 @@ namespace KeeperSecurity.Vault
             folderUid = null;
             if (operation == KeeperNSFRecordRemoveOperation.OwnerTrash)
             {
+                if (!string.IsNullOrWhiteSpace(folderUidOrName))
+                {
+                    if (!TryResolveKeeperNSFFolder(folderUidOrName, out var ownerTrashFolder))
+                    {
+                        return false;
+                    }
+
+                    folderUid = GetKeeperNSFApiFolderUid(ownerTrashFolder);
+                }
+                else
+                {
+                    folderUid = GetKeeperNSFFoldersForRecord(recordUid).FirstOrDefault();
+                }
+
                 return true;
             }
 

--- a/PowerCommander/NsfFolderCommands.ps1
+++ b/PowerCommander/NsfFolderCommands.ps1
@@ -77,6 +77,13 @@ function Set-KeeperNSFFolderAccess {
 	.Parameter Role
 	Access role for grant action: viewer (default), share-manager, content-manager,
 	content-share-manager, full-manager.
+
+	.Parameter ExpireIn
+	Optional. Share expiration period from now (e.g. 30d, 6mo, 1y, 24h, 30mi), integer minutes,
+	or a TimeSpan. Same as Grant-KeeperRecordAccess.
+
+	.Parameter ExpireAt
+	Optional. Absolute share expiration as ISO datetime (e.g. 2027-01-01T00:00:00Z).
 #>
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
@@ -93,7 +100,15 @@ function Set-KeeperNSFFolderAccess {
 
         [Parameter()]
         [ValidateSet('viewer', 'share-manager', 'content-manager', 'content-share-manager', 'full-manager')]
-        [string] $Role = 'viewer'
+        [string] $Role = 'viewer',
+
+        [Alias('expire-in')]
+        [Parameter()]
+        [System.Object] $ExpireIn,
+
+        [Alias('expire-at')]
+        [Parameter()]
+        [string] $ExpireAt
     )
 
     try {
@@ -109,11 +124,27 @@ function Set-KeeperNSFFolderAccess {
         return
     }
 
+    $shareOptions = $null
+    if ($Action -eq 'grant' -and ($ExpireIn -or $ExpireAt)) {
+        try {
+            $expirationDto = Get-ExpirationDate -ExpireIn $ExpireIn -ExpireAt $ExpireAt
+        }
+        catch {
+            Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red
+            return
+        }
+        $shareOptions = New-Object KeeperSecurity.Vault.SharedFolderUserOptions
+        $shareOptions.Expiration = $expirationDto
+    }
+
     foreach ($user in $Email) {
         try {
             if ($Action -eq 'grant') {
-                [void]$vault.GrantKeeperNSFFolderAccess($FolderUid, $user, $Role).GetAwaiter().GetResult()
-                Write-Host "Granted '$Role' access to '$user' on folder '$FolderUid'." -ForegroundColor Green
+                [void]$vault.GrantKeeperNSFFolderAccess($FolderUid, $user, $Role, $shareOptions).GetAwaiter().GetResult()
+                $expireMsg = if ($shareOptions -and $shareOptions.Expiration) {
+                    " (expires $($shareOptions.Expiration.LocalDateTime.ToString('g')))"
+                } else { '' }
+                Write-Host "Granted '$Role' access to '$user' on folder '$FolderUid'$expireMsg." -ForegroundColor Green
             }
             else {
                 [void]$vault.RevokeKeeperNSFFolderAccess($FolderUid, $user).GetAwaiter().GetResult()

--- a/PowerCommander/NsfRecordCommands.ps1
+++ b/PowerCommander/NsfRecordCommands.ps1
@@ -331,6 +331,13 @@ function Set-KeeperNSFRecordAccess {
 	.Parameter Role
 	Access role for grant action: viewer (default), share-manager, content-manager,
 	content-share-manager, full-manager.
+
+	.Parameter ExpireIn
+	Optional. Share expiration period from now (e.g. 30d, 6mo, 1y, 24h, 30mi), integer minutes,
+	or a TimeSpan. Same as Grant-KeeperRecordAccess.
+
+	.Parameter ExpireAt
+	Optional. Absolute share expiration as ISO datetime (e.g. 2027-01-01T00:00:00Z).
 #>
     [CmdletBinding()]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
@@ -347,7 +354,15 @@ function Set-KeeperNSFRecordAccess {
 
         [Parameter()]
         [ValidateSet('viewer', 'share-manager', 'content-manager', 'content-share-manager', 'full-manager')]
-        [string] $Role = 'viewer'
+        [string] $Role = 'viewer',
+
+        [Alias('expire-in')]
+        [Parameter()]
+        [System.Object] $ExpireIn,
+
+        [Alias('expire-at')]
+        [Parameter()]
+        [string] $ExpireAt
     )
 
     try {
@@ -363,11 +378,27 @@ function Set-KeeperNSFRecordAccess {
         return
     }
 
+    $shareOptions = $null
+    if ($Action -eq 'grant' -and ($ExpireIn -or $ExpireAt)) {
+        try {
+            $expirationDto = Get-ExpirationDate -ExpireIn $ExpireIn -ExpireAt $ExpireAt
+        }
+        catch {
+            Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red
+            return
+        }
+        $shareOptions = New-Object KeeperSecurity.Vault.SharedFolderRecordOptions
+        $shareOptions.Expiration = $expirationDto
+    }
+
     foreach ($user in $Email) {
         try {
             if ($Action -eq 'grant') {
-                [void]$vault.ShareKeeperNSFRecord($RecordUid, $user, $Role).GetAwaiter().GetResult()
-                Write-Host "Granted '$Role' access to '$user' on record '$RecordUid'." -ForegroundColor Green
+                [void]$vault.ShareKeeperNSFRecord($RecordUid, $user, $Role, $shareOptions).GetAwaiter().GetResult()
+                $expireMsg = if ($shareOptions -and $shareOptions.Expiration) {
+                    " (expires $($shareOptions.Expiration.LocalDateTime.ToString('g')))"
+                } else { '' }
+                Write-Host "Granted '$Role' access to '$user' on record '$RecordUid'$expireMsg." -ForegroundColor Green
             }
             else {
                 [void]$vault.UnshareKeeperNSFRecord($RecordUid, $user).GetAwaiter().GetResult()

--- a/PowerCommander/NsfRecordCommands.ps1
+++ b/PowerCommander/NsfRecordCommands.ps1
@@ -881,21 +881,13 @@ function Remove-KeeperNSFRecord {
     begin {
         [KeeperSecurity.Vault.VaultOnline]$vault = getVault
         $removals = New-Object 'System.Collections.Generic.List[KeeperSecurity.Vault.KeeperNSFRecordRemoval]'
-        $resolvedFolderUid = $null
+        $folderHint = $null
 
         if ($Folder) {
-            [KeeperSecurity.Vault.FolderNode]$folderNode = $null
-            if (-not $vault.TryResolveKeeperNSFFolder($Folder, [ref]$folderNode)) {
-                Write-Error -Message "Keeper NSF folder `"$Folder`" was not found. Run Sync-Keeper or nsf-list first."
-                return
-            }
-            $resolvedFolderUid = $folderNode.FolderUid
+            $folderHint = $Folder
         }
-        elseif ($Script:Context.CurrentFolder) {
-            [KeeperSecurity.Vault.FolderNode]$currentFolder = $null
-            if ($vault.TryResolveKeeperNSFFolder($Script:Context.CurrentFolder, [ref]$currentFolder)) {
-                $resolvedFolderUid = $currentFolder.FolderUid
-            }
+        elseif ($Operation -ne 'owner-trash' -and $Script:Context.CurrentFolder) {
+            $folderHint = $Script:Context.CurrentFolder
         }
 
         $op = switch ($Operation) {
@@ -904,7 +896,7 @@ function Remove-KeeperNSFRecord {
             'unlink' { [KeeperSecurity.Vault.KeeperNSFRecordRemoveOperation]::Unlink }
         }
 
-        if ($op -eq [KeeperSecurity.Vault.KeeperNSFRecordRemoveOperation]::Unlink -and -not $resolvedFolderUid) {
+        if ($op -eq [KeeperSecurity.Vault.KeeperNSFRecordRemoveOperation]::Unlink -and [string]::IsNullOrWhiteSpace($folderHint)) {
             Write-Error -Message "Folder context is required for unlink. Use -Folder or cd into a Keeper NSF folder."
             return
         }
@@ -918,14 +910,10 @@ function Remove-KeeperNSFRecord {
                 continue
             }
 
-            $folderUid = $resolvedFolderUid
-            if (-not $folderUid -and $op -ne [KeeperSecurity.Vault.KeeperNSFRecordRemoveOperation]::OwnerTrash) {
-                $folderUids = @($vault.GetKeeperNSFFoldersForRecord($kdRecord.RecordUid))
-                if ($folderUids.Count -eq 0) {
-                    Write-Error -Message "No folder context for record `"$name`". Use -Folder or -Operation owner-trash."
-                    continue
-                }
-                $folderUid = $folderUids[0]
+            [string]$folderUid = $null
+            if (-not $vault.TryResolveKeeperNSFRecordRemovalFolder($kdRecord.RecordUid, $folderHint, $op, [ref]$folderUid)) {
+                Write-Error -Message "No folder context for record `"$name`". Use -Folder or -Operation owner-trash."
+                continue
             }
 
             $removal = New-Object KeeperSecurity.Vault.KeeperNSFRecordRemoval
@@ -945,6 +933,15 @@ function Remove-KeeperNSFRecord {
         Write-Host "=== Keeper NSF Remove Preview ===" -ForegroundColor Cyan
         $previewResult = $vault.RemoveKeeperNSFRecords($removals, $true).GetAwaiter().GetResult()
         Write-KeeperNSFRemoveImpact -Response $previewResult.PreviewResponse
+
+        $previewErrors = @($previewResult.PreviewResponse.Results | Where-Object {
+                $_.Error -and -not [string]::IsNullOrWhiteSpace($_.Error.Message)
+            })
+        if ($previewErrors.Count -gt 0) {
+            Write-Host ""
+            Write-Host "One or more records could not be previewed. Aborting." -ForegroundColor Yellow
+            return
+        }
 
         try {
             [KeeperSecurity.Vault.VaultOnline]::ValidateRemoveResponse($previewResult.PreviewResponse, $false)

--- a/PowerCommander/NsfRecordCommands.ps1
+++ b/PowerCommander/NsfRecordCommands.ps1
@@ -884,6 +884,11 @@ function Remove-KeeperNSFRecord {
         $folderHint = $null
 
         if ($Folder) {
+            [KeeperSecurity.Vault.FolderNode]$folderNode = $null
+            if (-not $vault.TryResolveKeeperNSFFolder($Folder, [ref]$folderNode)) {
+                Write-Error -Message "Keeper NSF folder `"$Folder`" was not found. Run Sync-Keeper or nsf-list first."
+                return
+            }
             $folderHint = $Folder
         }
         elseif ($Operation -ne 'owner-trash' -and $Script:Context.CurrentFolder) {
@@ -912,7 +917,12 @@ function Remove-KeeperNSFRecord {
 
             [string]$folderUid = $null
             if (-not $vault.TryResolveKeeperNSFRecordRemovalFolder($kdRecord.RecordUid, $folderHint, $op, [ref]$folderUid)) {
-                Write-Error -Message "No folder context for record `"$name`". Use -Folder or -Operation owner-trash."
+                if ($Folder) {
+                    Write-Error -Message "Keeper NSF folder `"$Folder`" was not found. Run Sync-Keeper or nsf-list first."
+                }
+                else {
+                    Write-Error -Message "No folder context for record `"$name`". Use -Folder or -Operation owner-trash."
+                }
                 continue
             }
 

--- a/PowerCommander/SharedFolderCommands.ps1
+++ b/PowerCommander/SharedFolderCommands.ps1
@@ -10,12 +10,17 @@ function Get-KeeperSharedFolder {
 
 	.Parameter Filter
 	Return matching shared folders only
+
+	.Parameter RoeEligible
+	If set, only return shared folders eligible for rotate-on-expiration (contain a pamUser
+	record with rotation configured).
 #>
     [CmdletBinding()]
     [OutputType([KeeperSecurity.Vault.SharedFolder[]])]
     Param (
         [string] $Uid,
-        [string] $Filter
+        [string] $Filter,
+        [switch] $RoeEligible
     )
 
     [KeeperSecurity.Vault.VaultOnline]$vault = getVault
@@ -23,11 +28,18 @@ function Get-KeeperSharedFolder {
     [KeeperSecurity.Vault.SharedFolder] $sharedFolder = $null
     if ($Uid) {
         if ($vault.TryGetSharedFolder($uid, [ref]$sharedFolder)) {
-            $sharedFolder
+            if (-not $RoeEligible.IsPresent -or [KeeperSecurity.Vault.VaultShareExpirationExtensions]::SharedFolderHasPamUserWithRotation($vault, $sharedFolder.Uid)) {
+                $sharedFolder
+            }
         }
     }
     else {
-        foreach ($sharedFolder in $vault.SharedFolders) {
+        $folders = if ($RoeEligible.IsPresent) {
+            [KeeperSecurity.Vault.VaultShareExpirationExtensions]::SearchRoeEligibleSharedFolders($vault, $Filter)
+        } else {
+            $vault.SharedFolders
+        }
+        foreach ($sharedFolder in $folders) {
             if ($Filter) {
                 $match = $($sharedFolder.Uid, $sharedFolder.Name) | Select-String $Filter | Select-Object -First 1
                 if (-not $match) {

--- a/PowerCommander/Sharing.ps1
+++ b/PowerCommander/Sharing.ps1
@@ -293,6 +293,8 @@ function Parse-KeeperSharePeriod {
         [string] $Period
     )
 
+    $Period = $Period.Trim().ToLowerInvariant()
+
     if ($Period -match '^(\d+)(mi|minutes?|h|hours?|d|days?|mo|months?|y|years?)$') {
         $num = [int]$Matches[1]
         switch -Regex ($Matches[2]) {

--- a/PowerCommander/Sharing.ps1
+++ b/PowerCommander/Sharing.ps1
@@ -287,6 +287,26 @@ function Grant-KeeperRecordAccess {
 }
 New-Alias -Name kshr -Value Grant-KeeperRecordAccess
 
+function Parse-KeeperSharePeriod {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Period
+    )
+
+    if ($Period -match '^(\d+)(mi|minutes?|h|hours?|d|days?|mo|months?|y|years?)$') {
+        $num = [int]$Matches[1]
+        switch -Regex ($Matches[2]) {
+            '^(mi|minutes?)$' { return [TimeSpan]::FromMinutes($num) }
+            '^(h|hours?)$' { return [TimeSpan]::FromHours($num) }
+            '^(d|days?)$' { return [TimeSpan]::FromDays($num) }
+            '^(mo|months?)$' { return [TimeSpan]::FromDays($num * 30) }
+            '^(y|years?)$' { return [TimeSpan]::FromDays($num * 365) }
+        }
+    }
+
+    throw "Cannot parse period '$Period'. Valid units: mi, h, d, mo, y (e.g. 30d, 6mo, 1y)."
+}
+
 function Get-ExpirationDate {
     param(
         [object]$ExpireIn,
@@ -309,10 +329,15 @@ function Get-ExpirationDate {
             }
             else {
                 try {
-                    $expireOffset = [TimeSpan]::Parse($ExpireIn)
+                    $expireOffset = Parse-KeeperSharePeriod -Period $ExpireIn
                 }
                 catch {
-                    throw "Cannot parse ExpireIn string value '$ExpireIn' - not a number or valid TimeSpan string."
+                    try {
+                        $expireOffset = [TimeSpan]::Parse($ExpireIn)
+                    }
+                    catch {
+                        throw "Cannot parse ExpireIn string value '$ExpireIn' - not a number, period (e.g. 30d, 1h), or valid TimeSpan string."
+                    }
                 }
             }
         }

--- a/PowerCommander/Sharing.ps1
+++ b/PowerCommander/Sharing.ps1
@@ -199,6 +199,10 @@ function Grant-KeeperRecordAccess {
         .PARAMETER ExpireAt
             Optional. An absolute expiration time in ISO 8601 or RFC 1123 format (e.g., "2025-05-23T08:59:11Z" or "Fri, 23 May 2025 08:59:11 GMT").
 
+        .PARAMETER RotateOnExpiration
+            Rotate the password when share access expires. Requires a future expiration and a pamUser
+            record with rotation configured.
+
         .EXAMPLE
             Grant-KeeperRecordAccess -Record "XP-TKMqg9kIf4RXLuW4Qwg" -User "jane.doe@example.com" -CanEdit -CanShare
 
@@ -228,7 +232,9 @@ function Grant-KeeperRecordAccess {
         [Parameter()][switch]$CanEdit,
         [Parameter()][switch]$CanShare,
         [Parameter()][System.Object]$ExpireIn,
-        [Parameter()][string]$ExpireAt
+        [Parameter()][string]$ExpireAt,
+        [Alias('roe', 'rotate-on-expiration')]
+        [Parameter()][switch]$RotateOnExpiration
     )
 
     [KeeperSecurity.Vault.VaultOnline]$vault = getVault
@@ -252,6 +258,9 @@ function Grant-KeeperRecordAccess {
         $options.CanEdit = $CanEdit.IsPresent
         $options.CanShare = $CanShare.IsPresent
         $options.Expiration = $expiration
+        if ($RotateOnExpiration.IsPresent) {
+            $options.RotateOnExpiration = $true
+        }
     }catch  {
         Write-Error "Error: $($_.Exception.Message)" -ErrorAction Stop
         throw
@@ -268,7 +277,7 @@ function Grant-KeeperRecordAccess {
         if ($rec) {
             try {
                 $vault.ShareRecordWithUser($rec.Uid, $User, $options).GetAwaiter().GetResult() | Out-Null
-                Write-Output "Record `"$($rec.Title)`" was shared with $($User)"
+                Write-Output "Successfully shared the record $($rec.Uid) with user $User"
             }
             catch [KeeperSecurity.Vault.NoActiveShareWithUserException] {
                 Write-Output $_
@@ -477,6 +486,16 @@ function Grant-KeeperSharedFolderAccess {
         .Parameter ManageUsers
         Grant Manage Users permission
 
+        .Parameter ExpireIn
+        Optional. Share expiration period from now (e.g. 30d, 1h, 30mi).
+
+        .Parameter ExpireAt
+        Optional. Absolute share expiration as ISO datetime.
+
+        .Parameter RotateOnExpiration
+        Rotate the password when share access expires. Requires expiration and a pamUser
+        record with rotation configured in the folder.
+
     #>
 
     [CmdletBinding()]
@@ -485,7 +504,11 @@ function Grant-KeeperSharedFolderAccess {
         [Parameter(Mandatory = $true, ParameterSetName='user')]$User,
         [Parameter(Mandatory = $true, ParameterSetName='team')]$Team,
         [Parameter()][switch]$ManageRecords,
-        [Parameter()][switch]$ManageUsers
+        [Parameter()][switch]$ManageUsers,
+        [Parameter()][System.Object]$ExpireIn,
+        [Parameter()][string]$ExpireAt,
+        [Alias('roe', 'rotate-on-expiration')]
+        [Parameter()][switch]$RotateOnExpiration
     )
 
     [KeeperSecurity.Vault.VaultOnline]$private:vault = getVault
@@ -556,6 +579,12 @@ function Grant-KeeperSharedFolderAccess {
         $options = New-Object KeeperSecurity.Vault.SharedFolderUserOptions
         $options.ManageRecords = $ManageRecords.IsPresent
         $options.ManageUsers = $ManageUsers.IsPresent
+        if ($ExpireIn -or $ExpireAt) {
+            $options.Expiration = Get-ExpirationDate -ExpireIn $ExpireIn -ExpireAt $ExpireAt
+        }
+        if ($RotateOnExpiration.IsPresent) {
+            $options.RotateOnExpiration = $true
+        }
         $vault.PutUserToSharedFolder($sf.Uid, $userId, $userType, $options).GetAwaiter().GetResult() | Out-Null
         Write-Output "${userType} `"$($userName)`" has been added to shared folder `"$($sf.Name)`""
     }

--- a/PowerCommander/Sharing.ps1
+++ b/PowerCommander/Sharing.ps1
@@ -313,6 +313,15 @@ function Get-ExpirationDate {
         [string]$ExpireAt
     )
 
+    if ($ExpireAt) {
+        try {
+            return [DateTimeOffset]::Parse($ExpireAt)
+        }
+        catch {
+            throw "Cannot parse ExpireAt: '$ExpireAt'. Must be a valid ISO 8601 or RFC 1123 string."
+        }
+    }
+
     $expireOffset = $null
 
     if ($ExpireIn) {
@@ -347,17 +356,8 @@ function Get-ExpirationDate {
 
         return [DateTimeOffset]::UtcNow.Add($expireOffset)
     }
-    elseif ($ExpireAt) {
-        try {
-            return [DateTimeOffset]::Parse($ExpireAt)
-        }
-        catch {
-            throw "Cannot parse ExpireAt: '$ExpireAt'. Must be a valid ISO 8601 or RFC 1123 string."
-        }
-    }
-    else {
-        return $null  # No expiration
-    }
+
+    return $null  # No expiration
 }
 
 function Revoke-KeeperRecordAccess {

--- a/PowerCommander/SkipSyncCommands.ps1
+++ b/PowerCommander/SkipSyncCommands.ps1
@@ -61,7 +61,8 @@ function __NewSharedFolderUserOptionsSkipSync {
     param(
         [System.Nullable[bool]] $ManageRecords,
         [System.Nullable[bool]] $ManageUsers,
-        [System.Nullable[DateTimeOffset]] $Expiration
+        [System.Nullable[DateTimeOffset]] $Expiration,
+        [switch] $RotateOnExpiration
     )
     $options = New-Object KeeperSecurity.Vault.SharedFolderUserOptions
     if ($null -ne $ManageRecords) {
@@ -78,6 +79,9 @@ function __NewSharedFolderUserOptionsSkipSync {
         $options.Expiration = $Expiration
     } else {
         $options.Expiration = $null
+    }
+    if ($RotateOnExpiration.IsPresent) {
+        $options.RotateOnExpiration = $true
     }
     return $options
 }
@@ -647,6 +651,10 @@ function Grant-KeeperSharedFolderUserSkipSync {
 
     .PARAMETER ExpireAt
     Optional. Absolute expiration as ISO 8601 or RFC 1123 (e.g. "2025-05-23T08:59:11Z").
+
+    .PARAMETER RotateOnExpiration
+    Rotate the password when share access expires. Requires expiration and a pamUser record
+    with rotation configured in the folder.
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
@@ -656,6 +664,8 @@ function Grant-KeeperSharedFolderUserSkipSync {
         [Parameter()][System.Nullable[bool]] $ManageUsers,
         [Parameter()][System.Object] $ExpireIn,
         [Parameter()][string] $ExpireAt,
+        [Alias('roe', 'rotate-on-expiration')]
+        [Parameter()][switch] $RotateOnExpiration,
         [Parameter()][switch] $ShowDetail,
         [Parameter()][switch] $PassThru
     )
@@ -668,7 +678,7 @@ function Grant-KeeperSharedFolderUserSkipSync {
         Write-Error "Error: $($_.Exception.Message)" -ErrorAction Stop
         throw
     }
-    $options = __NewSharedFolderUserOptionsSkipSync -ManageRecords $ManageRecords -ManageUsers $ManageUsers -Expiration $expirationDto
+    $options = __NewSharedFolderUserOptionsSkipSync -ManageRecords $ManageRecords -ManageUsers $ManageUsers -Expiration $expirationDto -RotateOnExpiration:$RotateOnExpiration.IsPresent
     $didGrant = $false
     if ($PSCmdlet.ShouldProcess("$sfUid", "Grant shared folder access to $email")) {
         $auth = getKeeperAuth
@@ -743,6 +753,10 @@ function Grant-KeeperSharedFolderTeamSkipSync {
 
     .PARAMETER ExpireAt
     Optional. Absolute expiration (ISO 8601 or RFC 1123).
+
+    .PARAMETER RotateOnExpiration
+    Rotate the password when share access expires. Requires expiration and a pamUser record
+    with rotation configured in the folder.
     #>
     [CmdletBinding(SupportsShouldProcess = $true)]
     Param(
@@ -752,6 +766,8 @@ function Grant-KeeperSharedFolderTeamSkipSync {
         [Parameter()][System.Nullable[bool]] $ManageUsers,
         [Parameter()][System.Object] $ExpireIn,
         [Parameter()][string] $ExpireAt,
+        [Alias('roe', 'rotate-on-expiration')]
+        [Parameter()][switch] $RotateOnExpiration,
         [Parameter()][switch] $ShowDetail,
         [Parameter()][switch] $PassThru
     )
@@ -764,7 +780,7 @@ function Grant-KeeperSharedFolderTeamSkipSync {
         Write-Error "Error: $($_.Exception.Message)" -ErrorAction Stop
         throw
     }
-    $options = __NewSharedFolderUserOptionsSkipSync -ManageRecords $ManageRecords -ManageUsers $ManageUsers -Expiration $expirationDto
+    $options = __NewSharedFolderUserOptionsSkipSync -ManageRecords $ManageRecords -ManageUsers $ManageUsers -Expiration $expirationDto -RotateOnExpiration:$RotateOnExpiration.IsPresent
     $didGrant = $false
     if ($PSCmdlet.ShouldProcess("$sfUid", "Grant shared folder access to team $Team")) {
         $auth = getKeeperAuth


### PR DESCRIPTION
SDk 481: nsf-rm with -Operation owner-trash returns "Insufficient permission" error
SDK 482: nsf-share-folder & nsf-share-record commands missing --expire-in and --expire-at flags


