### PR TITLE
Fix BreachWatch status mapping

### DIFF
--- a/PowerCommander/SecurityAuditReport.ps1
+++ b/PowerCommander/SecurityAuditReport.ps1
@@ -188,18 +188,16 @@ function Script:Get-KeeperSecurityScoreDeltas {
     }
     $deltas.total_record_passwords = $Delta
 
-    # bw_result from the API: 2 = at-risk (breached), 1 = passed (clean), 0/other = ignored
+    # BWStatus: Good=0, Changed=1, Weak=2, Breached=3, Ignore=4
     $breachWatchResult = ConvertTo-KeeperInt (Get-KeeperJsonPropertyValue $RecordSecurityData 'bw_result')
-    if ($breachWatchResult -eq 2) {
-        $deltas.at_risk_records = $Delta
+    switch ($breachWatchResult) {
+        0       { $deltas.passed_records  = $Delta }  # Good
+        1       { $deltas.passed_records  = $Delta }  # Changed
+        2       { $deltas.at_risk_records = $Delta }  # Weak
+        3       { $deltas.at_risk_records = $Delta }  # Breached
+        4       { $deltas.ignored_records = $Delta }  # Ignore
+        default { $deltas.ignored_records = $Delta }  # unknown
     }
-    elseif ($breachWatchResult -eq 1) {
-        $deltas.passed_records = $Delta
-    }
-    else {
-        $deltas.ignored_records = $Delta
-    }
-
     return $deltas
 }
 


### PR DESCRIPTION
# Summary
Get-KeeperBreachWatchReport returns incorrect At Risk / Passed / Ignored counts. Record totals match the Admin Console, but the per-record classification is wrong: clean (Good) and Breached records are both counted as Ignored.

# Steps to reproduce
1. In the vault of a user belonging to a managed company, create a record with a strong password. BreachWatch reports it as Good and the Admin Console counts it under Passed.
2. Sign in with PowerCommander as the MSP administrator: Connect-Keeper <admin>
3. Switch to the managed company: Switch-KeeperMC <company-id>
4. Run Get-KeeperBreachWatchReport
5. The record is counted under Ignored instead of Passed, so the output matches neither the Admin Console nor the actual vault contents.(A Breached record should show the same defect: the console counts it under At Risk, the report counts it under Ignored.)

In a managed company, the incorrect counts appeared consistently. In the enterprise/MSP tenant they did not — possibly because the report is served from the stored summary data there.



# Root cause:
Get-KeeperSecurityScoreDeltas in PowerCommander/SecurityAuditReport.ps1 buckets each record's bw_result as 2 -> at_risk, 1 -> passed, and an else catch-all sending everything else to ignored.

bw_result follows the BWStatus enum (KeeperSdk/proto/Client.cs): Good = 0, Changed = 1, Weak = 2, Breached = 3, Ignore = 4. Only 1 and 2 are handled, so Good(0) and Breached(3) fall into the catch-all.

The existing comment records the incorrect assumption:
`# bw_result from the API: 2 = at-risk (breached), 1 = passed (clean), 0/other = ignored
2 is Weak, not Breached. Breached is 3 and never reaches at_risk.`


# Fix:
Replace the three-way branch with an explicit switch over every defined BWStatus value. The default branch continues to classify unrecognized numeric values as ignored. This change was validated on a Windows VM with the modified SecurityAuditReport.ps1, and the resulting BreachWatch classifications matched the Admin Console.